### PR TITLE
Remove redundant ".0" from version strings in URLs

### DIFF
--- a/content/docs/1.61/operator.md
+++ b/content/docs/1.61/operator.md
@@ -69,7 +69,7 @@ Make sure your `kubectl` command is properly configured to talk to a valid Kuber
 To install the operator, run:
 ```bash
 kubectl create namespace observability # <1>
-kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}.0/jaeger-operator.yaml -n observability # <2>
+kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}/jaeger-operator.yaml -n observability # <2>
 ```
 <1> This creates the namespace used by default in the deployment files. If you want to install the Jaeger operator in a different namespace, you must edit the deployment files to change `observability` to the desired namespace value.
 
@@ -98,7 +98,7 @@ The instructions from the previous section also work for installing the operator
 oc login -u <privileged user>
 
 oc new-project observability # <1>
-oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}.0/jaeger-operator.yaml -n observability # <2>
+oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}/jaeger-operator.yaml -n observability # <2>
 ```
 <1> This creates the namespace used by default in the deployment files. If you want to install the Jaeger operator in a different namespace, you must edit the deployment files to change `observability` to the desired namespace value.
 
@@ -1457,5 +1457,5 @@ The Jaeger Operator does not yet publish its own metrics. Rather, it makes avail
 To uninstall the operator, run the following commands:
 
 ```bash
-kubectl delete -n observability -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}.0/jaeger-operator.yaml
+kubectl delete -n observability -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}/jaeger-operator.yaml
 ```


### PR DESCRIPTION
The "currentVersion" url appears to already be of the format "x.y.z" so the additional hardcoded ".0" in the URLs is creating broken links.